### PR TITLE
Allow filezilla's header ad

### DIFF
--- a/lists/opensource.txt
+++ b/lists/opensource.txt
@@ -1,0 +1,3 @@
+! Filezilla Ads are blocked by generic rules on the EasyList
+@@ads.filezilla-project.org
+filezilla-project.org#@#.TopAd


### PR DESCRIPTION
Filezilla runs a single banner ad hosted from their own domain.